### PR TITLE
Support tags, both server-wide and per-job

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,11 +9,12 @@ import (
 
 // Config is the base of our configuration data structure
 type Config struct {
-	Jobs                    []Job          `yaml:"jobs"`
-	Selenium                SeleniumConfig `yaml:"selenium"`
-	Storage                 StorageConfig  `yaml:"storage,omitempty"`
-	ReportInternalMetrics   bool           `yaml:"report-internal-metrics,omitempty"`
-	InternalMetricsInterval uint           `yaml:"internal-metrics-gathering-interval,omitempty"`
+	Jobs                    []Job             `yaml:"jobs"`
+	Selenium                SeleniumConfig    `yaml:"selenium"`
+	Storage                 StorageConfig     `yaml:"storage,omitempty"`
+	ReportInternalMetrics   bool              `yaml:"report-internal-metrics,omitempty"`
+	InternalMetricsInterval uint              `yaml:"internal-metrics-gathering-interval,omitempty"`
+	ServerTags              map[string]string `yaml:"server-tags,omitempty"`
 }
 
 // SeleniumConfig holds the configuration for our Selenium service

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -32,7 +32,7 @@ storage:
         port: 8125
         metric-namespace: crabby.crabby-sfo-1
         tags:
-            - crabby-sfo-1
+            - instance: crabby-sfo-1
     prometheus:
         host: prometheus.mysite.org
         port: 9091
@@ -42,6 +42,8 @@ storage:
         port: 5555
         metric-namespace: crabby.crabby-sfo-1
         tags:
-            - crabby-sfo-1
+            - instance: crabby-sfo-1
 report-internal-metrics: true
 internal-metrics-gathering-interval: 15
+server-tags:
+    - region: us-east-1

--- a/selenium.go
+++ b/selenium.go
@@ -120,20 +120,11 @@ func RunSeleniumTest(j Job, seleniumServer string, storage *Storage) {
 		return
 	}
 
-	fmt.Println(j.Name, "DNS time:", wr.ri.dnsDuration)
-	storage.MetricDistributor <- makeMetric(j.Name, "dns_duration", wr.ri.dnsDuration)
-
-	fmt.Println(j.Name, "Connection establishment time", wr.ri.serverConnectionDuration)
-	storage.MetricDistributor <- makeMetric(j.Name, "server_connection_duration", wr.ri.serverConnectionDuration)
-
-	fmt.Println(j.Name, "Response time:", wr.ri.serverResponseDuration)
-	storage.MetricDistributor <- makeMetric(j.Name, "server_response_duration", wr.ri.serverResponseDuration)
-
-	fmt.Println(j.Name, "Server processing time:", wr.ri.serverProcessingDuration)
-	storage.MetricDistributor <- makeMetric(j.Name, "server_processing_duration", wr.ri.serverProcessingDuration)
-
-	fmt.Println(j.Name, "DOM rendering time:", wr.ri.domRenderingDuration)
-	storage.MetricDistributor <- makeMetric(j.Name, "dom_rendering_duration", wr.ri.domRenderingDuration)
+	storage.MetricDistributor <- makeMetric(j, "dns_duration", wr.ri.dnsDuration)
+	storage.MetricDistributor <- makeMetric(j, "server_connection_duration", wr.ri.serverConnectionDuration)
+	storage.MetricDistributor <- makeMetric(j, "server_response_duration", wr.ri.serverResponseDuration)
+	storage.MetricDistributor <- makeMetric(j, "server_processing_duration", wr.ri.serverProcessingDuration)
+	storage.MetricDistributor <- makeMetric(j, "dom_rendering_duration", wr.ri.domRenderingDuration)
 
 	err = wr.wd.Close()
 	if err != nil {

--- a/simple.go
+++ b/simple.go
@@ -88,7 +88,7 @@ func RunSimpleTest(ctx context.Context, j Job, storage *Storage, client *http.Cl
 	}
 
 	// Send our server response code as an event
-	storage.EventDistributor <- makeEvent(j.Name, resp.StatusCode)
+	storage.EventDistributor <- makeEvent(j, resp.StatusCode)
 
 	// Even though we never read the response body, if we don't close it,
 	// the http.Transport goroutines will terminate and the app will eventually
@@ -109,16 +109,16 @@ func RunSimpleTest(ctx context.Context, j Job, storage *Storage, client *http.Cl
 
 	switch url.Scheme {
 	case "https":
-		storage.MetricDistributor <- makeMetric(j.Name, "dns_duration", t1.Sub(t0).Seconds()*1000)
-		storage.MetricDistributor <- makeMetric(j.Name, "server_connection_duration", t2.Sub(t1).Seconds()*1000)
-		storage.MetricDistributor <- makeMetric(j.Name, "tls_handshake_duration", t3.Sub(t2).Seconds()*1000)
-		storage.MetricDistributor <- makeMetric(j.Name, "server_processing_duration", t4.Sub(t3).Seconds()*1000)
-		storage.MetricDistributor <- makeMetric(j.Name, "server_response_duration", t5.Sub(t4).Seconds()*1000)
+		storage.MetricDistributor <- makeMetric(j, "dns_duration", t1.Sub(t0).Seconds()*1000)
+		storage.MetricDistributor <- makeMetric(j, "server_connection_duration", t2.Sub(t1).Seconds()*1000)
+		storage.MetricDistributor <- makeMetric(j, "tls_handshake_duration", t3.Sub(t2).Seconds()*1000)
+		storage.MetricDistributor <- makeMetric(j, "server_processing_duration", t4.Sub(t3).Seconds()*1000)
+		storage.MetricDistributor <- makeMetric(j, "server_response_duration", t5.Sub(t4).Seconds()*1000)
 
 	case "http":
-		storage.MetricDistributor <- makeMetric(j.Name, "dns_duration", t1.Sub(t0).Seconds()*1000)
-		storage.MetricDistributor <- makeMetric(j.Name, "server_connection_duration", t3.Sub(t1).Seconds()*1000)
-		storage.MetricDistributor <- makeMetric(j.Name, "server_processing_duration", t4.Sub(t3).Seconds()*1000)
-		storage.MetricDistributor <- makeMetric(j.Name, "server_response_duration", t5.Sub(t4).Seconds()*1000)
+		storage.MetricDistributor <- makeMetric(j, "dns_duration", t1.Sub(t0).Seconds()*1000)
+		storage.MetricDistributor <- makeMetric(j, "server_connection_duration", t3.Sub(t1).Seconds()*1000)
+		storage.MetricDistributor <- makeMetric(j, "server_processing_duration", t4.Sub(t3).Seconds()*1000)
+		storage.MetricDistributor <- makeMetric(j, "server_response_duration", t5.Sub(t4).Seconds()*1000)
 	}
 }

--- a/storage.go
+++ b/storage.go
@@ -12,6 +12,7 @@ import (
 type Metric struct {
 	Name      string
 	Value     float64
+	Tags      map[string]string
 	Timestamp time.Time
 }
 
@@ -19,6 +20,7 @@ type Metric struct {
 type Event struct {
 	Name         string
 	ServerStatus int
+	Tags         map[string]string
 	Timestamp    time.Time
 }
 
@@ -168,24 +170,32 @@ func (s *Storage) storageDistributor(ctx context.Context, wg *sync.WaitGroup) er
 }
 
 // makeMetric creates a Metric from raw values and metric names
-func makeMetric(name string, timing string, value float64) Metric {
+func makeMetric(j Job, timing string, value float64) Metric {
 
 	m := Metric{
-		Name:      fmt.Sprintf("%v.%v", name, timing),
+		Name:      fmt.Sprintf("%v.%v", j.Name, timing),
 		Value:     value,
 		Timestamp: time.Now(),
+	}
+
+	for k, v := range j.Tags {
+		m.Tags[k] = v
 	}
 
 	return m
 }
 
 // makeEvent creates an Event from raw values and event names
-func makeEvent(name string, status int) Event {
+func makeEvent(j Job, status int) Event {
 
 	e := Event{
-		Name:         name,
+		Name:         j.Name,
 		ServerStatus: status,
 		Timestamp:    time.Now(),
+	}
+
+	for k, v := range j.Tags {
+		e.Tags[k] = v
 	}
 
 	return e

--- a/storage.go
+++ b/storage.go
@@ -11,6 +11,7 @@ import (
 // Metric holds one metric data point
 type Metric struct {
 	Name      string
+	Timing    string
 	Value     float64
 	Tags      map[string]string
 	Timestamp time.Time
@@ -173,7 +174,8 @@ func (s *Storage) storageDistributor(ctx context.Context, wg *sync.WaitGroup) er
 func makeMetric(j Job, timing string, value float64) Metric {
 
 	m := Metric{
-		Name:      fmt.Sprintf("%v.%v", j.Name, timing),
+		Name:      j.Name,
+		Timing:    timing,
 		Value:     value,
 		Timestamp: time.Now(),
 	}

--- a/storage_dogstatsd.go
+++ b/storage_dogstatsd.go
@@ -12,10 +12,9 @@ import (
 // DogstatsdConfig describes the YAML-provided configuration for a Datadog
 // DogstatsD storage backend
 type DogstatsdConfig struct {
-	Host      string            `yaml:"host"`
-	Port      int               `yaml:"port"`
-	Namespace string            `yaml:"metric-namespace"`
-	Tags      map[string]string `yaml:"tags,omitempty"`
+	Host      string `yaml:"host"`
+	Port      int    `yaml:"port"`
+	Namespace string `yaml:"metric-namespace"`
 }
 
 // DogstatsdStorage holds the configuration for a DogstatsD storage backend
@@ -133,8 +132,5 @@ func NewDogstatsdStorage(c *Config) DogstatsdStorage {
 		log.Println("Warning: could not create dogstatsd connection", err)
 	}
 
-	for k, v := range c.Storage.Dogstatsd.Tags {
-		d.DogstatsdConn.Tags = append(d.DogstatsdConn.Tags, k+":"+v)
-	}
 	return d
 }

--- a/storage_dogstatsd.go
+++ b/storage_dogstatsd.go
@@ -64,9 +64,9 @@ func (d DogstatsdStorage) sendMetric(m Metric) error {
 	var metricName string
 
 	if d.Namespace == "" {
-		metricName = fmt.Sprintf("crabby.%v", m.Name)
+		metricName = fmt.Sprintf("crabby.%v.%v", m.Name, m.Timing)
 	} else {
-		metricName = fmt.Sprintf("%v.%v", d.Namespace, m.Name)
+		metricName = fmt.Sprintf("%v.%v.%v", d.Namespace, m.Name, m.Timing)
 	}
 
 	// Add all of our metric tags to the metric payload
@@ -76,7 +76,7 @@ func (d DogstatsdStorage) sendMetric(m Metric) error {
 
 	err := d.DogstatsdConn.TimeInMilliseconds(metricName, m.Value, nil, 1)
 	if err != nil {
-		log.Printf("Could not send metric %v: %v\n", m.Name, err)
+		log.Printf("Could not send metric %v.%v: %v\n", m.Name, m.Timing, err)
 		return err
 	}
 

--- a/storage_graphite.go
+++ b/storage_graphite.go
@@ -67,9 +67,9 @@ func (g GraphiteStorage) sendMetric(m Metric) error {
 	valStr := strconv.FormatFloat(m.Value, 'f', 3, 64)
 
 	if g.Namespace == "" {
-		metricName = fmt.Sprintf("crabby.%v", m.Name)
+		metricName = fmt.Sprintf("crabby.%v.%v", m.Name, m.Timing)
 	} else {
-		metricName = fmt.Sprintf("%v.%v", g.Namespace, m.Name)
+		metricName = fmt.Sprintf("%v.%v.%v", g.Namespace, m.Name, m.Timing)
 	}
 
 	if m.Timestamp.IsZero() {
@@ -89,7 +89,7 @@ func (g GraphiteStorage) sendMetric(m Metric) error {
 
 	err := g.GraphiteConn.SendMetric(gm)
 	if err != nil {
-		log.Printf("Could not send metric %v: %v\n", m.Name, err)
+		log.Printf("Could not send metric %v.%v: %v\n", m.Name, m.Timing, err)
 		return err
 	}
 

--- a/storage_riemann.go
+++ b/storage_riemann.go
@@ -12,10 +12,10 @@ import (
 // RiemannConfig describes the YAML-provided configuration for a Riemann
 // storage backend
 type RiemannConfig struct {
-	Host      string   `yaml:"host"`
-	Port      int      `yaml:"port"`
-	Namespace string   `yaml:"metric-namespace,omitempty"`
-	Tags      []string `yaml:"tags,omitempty"`
+	Host      string            `yaml:"host"`
+	Port      int               `yaml:"port"`
+	Namespace string            `yaml:"metric-namespace,omitempty"`
+	Tags      map[string]string `yaml:"tags,omitempty"`
 }
 
 // RiemannStorage holds the configuration for a Riemann storage backend
@@ -30,7 +30,10 @@ func NewRiemannStorage(c *Config) (RiemannStorage, error) {
 	r := RiemannStorage{}
 
 	r.Namespace = c.Storage.Riemann.Namespace
-	r.Tags = c.Storage.Riemann.Tags
+
+	for k, v := range c.Storage.Riemann.Tags {
+		r.Tags = append(r.Tags, k+":"+v)
+	}
 
 	r.Client = goryman.NewGorymanClient(fmt.Sprint(c.Storage.Riemann.Host, ":", c.Storage.Riemann.Port))
 	err := r.Client.Connect()

--- a/storage_riemann.go
+++ b/storage_riemann.go
@@ -12,10 +12,9 @@ import (
 // RiemannConfig describes the YAML-provided configuration for a Riemann
 // storage backend
 type RiemannConfig struct {
-	Host      string            `yaml:"host"`
-	Port      int               `yaml:"port"`
-	Namespace string            `yaml:"metric-namespace,omitempty"`
-	Tags      map[string]string `yaml:"tags,omitempty"`
+	Host      string `yaml:"host"`
+	Port      int    `yaml:"port"`
+	Namespace string `yaml:"metric-namespace,omitempty"`
 }
 
 // RiemannStorage holds the configuration for a Riemann storage backend
@@ -30,10 +29,6 @@ func NewRiemannStorage(c *Config) (RiemannStorage, error) {
 	r := RiemannStorage{}
 
 	r.Namespace = c.Storage.Riemann.Namespace
-
-	for k, v := range c.Storage.Riemann.Tags {
-		r.Tags = append(r.Tags, k+":"+v)
-	}
 
 	r.Client = goryman.NewGorymanClient(fmt.Sprint(c.Storage.Riemann.Host, ":", c.Storage.Riemann.Port))
 	err := r.Client.Connect()

--- a/storage_riemann.go
+++ b/storage_riemann.go
@@ -85,9 +85,9 @@ func (r RiemannStorage) sendMetric(m Metric) error {
 	var metricName string
 
 	if r.Namespace == "" {
-		metricName = fmt.Sprintf("crabby.%v", m.Name)
+		metricName = fmt.Sprintf("crabby.%v.%v", m.Name, m.Timing)
 	} else {
-		metricName = fmt.Sprintf("%v.%v", r.Namespace, m.Name)
+		metricName = fmt.Sprintf("%v.%v.%v", r.Namespace, m.Name, m.Timing)
 	}
 
 	ev := &goryman.Event{

--- a/storage_riemann.go
+++ b/storage_riemann.go
@@ -93,6 +93,10 @@ func (r RiemannStorage) sendMetric(m Metric) error {
 		Tags:    r.Tags,
 	}
 
+	for k, v := range m.Tags {
+		ev.Tags = append(ev.Tags, k+":"+v)
+	}
+
 	err := r.Client.SendEvent(ev)
 	if err != nil {
 		return err
@@ -122,6 +126,10 @@ func (r RiemannStorage) sendEvent(e Event) error {
 		Service: eventName,
 		State:   state,
 		Tags:    r.Tags,
+	}
+
+	for k, v := range e.Tags {
+		ev.Tags = append(ev.Tags, k+":"+v)
 	}
 
 	err := r.Client.SendEvent(ev)


### PR DESCRIPTION
This PR adds support for `key: value` tags on metrics and events.  You can add tags to all jobs on the server, just certain jobs, or just for particular storage backends.